### PR TITLE
Remove react and react-dom as peerDeps

### DIFF
--- a/src/app-code/package.json
+++ b/src/app-code/package.json
@@ -7,9 +7,7 @@
   },
   "dependencies": {
     "vendor-code": "../vendor-code",
-    "component-code": "../component-code",
-    "react": "^15.4.2",
-    "react-dom": "^15.4.2"
+    "component-code": "../component-code"
   },
   "devDependencies": {
     "webpack": "^2.2.0",

--- a/src/component-code/package.json
+++ b/src/component-code/package.json
@@ -5,8 +5,7 @@
     "build": "webpack"
   },
   "dependencies": {
-    "vendor-code": "../vendor-code",
-    "react": "^15.4.2"
+    "vendor-code": "../vendor-code"
   },
   "files": [
     "index.js",

--- a/src/vendor-code/package.json
+++ b/src/vendor-code/package.json
@@ -12,10 +12,6 @@
     "index.js",
     "output"
   ],
-  "peerDependencies": {
-    "react": "^15.4.2",
-    "react-dom": "^15.4.2"
-  },
   "devDependencies": {
     "webpack": "^2.2.0"
   }


### PR DESCRIPTION
Just like the title says :) `react` and `react-dom` are no longer peerDependencies in the vendor package. This means that those libraries don't need to be explicity included as dependencies in the component or app code projects. Both libraries still come along as part of the normal dependency chain because they are included as dependencies in the vendor dll, but they no longer have to be explicitly called out as dependencies in the consuming projects.